### PR TITLE
Stop duplicate form from appearing in prompts

### DIFF
--- a/app/views/prompts/create.js.erb
+++ b/app/views/prompts/create.js.erb
@@ -1,8 +1,8 @@
 $('#prompt_new').show();
+$('.new_prompt').remove();
 if ($('form').last().find('input').val() %2 == 0){
   var partial = "<%= j render partial: 'prompts/right', locals: { prompt: @prompt } %>"
 }else {
   var partial = "<%= j render partial: 'prompts/left', locals: { prompt: @prompt } %>"
 }
-debugger;
-$('#list_of_prompts').append(partial);
+$('#list_of_prompts').prepend(partial);

--- a/app/views/prompts/new.html.erb
+++ b/app/views/prompts/new.html.erb
@@ -4,7 +4,7 @@
          <div class="main-slider">
            <div class="col-sm-4 col-sm-offset-4 text-center">
              <h1 class="margin-bottom">New prompt</h1>
-             <%= render 'form' %> 
+             <%# render 'form' %> 
            </div>
          </div>
        </div>


### PR DESCRIPTION
Bug fixed!  Also, I made two design choices here I'm not attached to: 

1) I left post order the way it is figuring there was a grand plan. Currently new posts fall to the bottom, but then you can't see the fancy AJAX and it looks like nothing has happened.  Might be better to show posts in reverse chronological order.

2) To keep the user from repeatedly clicking since they can't see their new post, I flash a JS "success" message.  This is fun but inconsistent with our flash messages elsewhere.
