### PR TITLE
Correct prompt sample & add link to recent response

### DIFF
--- a/app/controllers/prompts_controller.rb
+++ b/app/controllers/prompts_controller.rb
@@ -4,7 +4,7 @@ class PromptsController < ApplicationController
 
   # GET /prompts
   def index
-    @prompts = Prompt.sample(20)
+    @prompts = Prompt.limit(20).order("RANDOM()")
   end
 
   # GET /prompts/:id

--- a/app/views/prompts/_single_prompt_footer.html.erb
+++ b/app/views/prompts/_single_prompt_footer.html.erb
@@ -1,9 +1,12 @@
 <div class="post-bottom overflow">
   <span class="post-date pull-left">
     <% if prompt.responders.include? current_user %>
-      <i class="fa fa-check-circle"></i>
-      You responded
-      <%= time_ago_in_words prompt.last_response_by(current_user).created_at %> ago
+      <%= link_to prompt_path(prompt.last_response_by(current_user)) do %>
+        <i class="fa fa-check-circle"></i>
+        You responded
+        <%= time_ago_in_words prompt.last_response_by(current_user).created_at %>
+        ago
+      <% end %>
     <% else %>
       <i class="fa fa-clock-o"></i>
       <%= time_ago_in_words prompt.created_at %> ago


### PR DESCRIPTION
So it turns out `Model.sample` is no bueno. This corrects that with a specific query, check out more [here](http://hashrocket.com/blog/posts/rails-quick-tips-random-records).

Add a link in individual prompt footer, after you have responded, that takes you to your response.
