### PR TITLE
Prepend new prompt correctly

### DIFF
--- a/app/controllers/prompts_controller.rb
+++ b/app/controllers/prompts_controller.rb
@@ -28,20 +28,10 @@ class PromptsController < ApplicationController
   def create
     # TODO: refactor
     @prompt = current_user.prompts.new(prompt_params)
-    if @prompt.concepts
-      @prompt.concepts.each do |concept|
-        concept.user = current_user
-        concept.save
-      end
+    @prompt.concepts.each do |concept|
+      concept.user ||= current_user
     end
-    if @prompt.save
-      respond_to do |format|
-        format.html { redirect_to @prompt }
-        format.js
-      end
-    else
-      render :new
-    end
+    render :new unless @prompt.save
   end
 
   # GET prompts/:id/responses/new
@@ -52,10 +42,6 @@ class PromptsController < ApplicationController
   def create_response
     @prompt.responses << current_user.prompts.new(prompt_params)
     @prompt.save
-
-    respond_to do |format|
-      format.js
-    end
   end
 
   private

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -11,15 +11,14 @@ class Character < ActiveRecord::Base
     super.uniq
   end
 
-  def normalize_name
-    name.downcase.titleize
-  end
 
   def to_s
-    name
+    "@#{name.gsub(/[ \.]/, '')}"
   end
 
-  def hash_tag
-    "##{name.downcase.gsub(' ', '')}"
+  private
+
+  def normalize_name
+    name.downcase.titleize
   end
 end

--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -18,6 +18,10 @@ class Prompt < ActiveRecord::Base
 
   validates :body, presence: true
 
+  def to_s
+    prompt.body
+  end
+
   def last_response_by(user)
     responses.where(user_id: user).last
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,4 +11,8 @@ class User < ActiveRecord::Base
   validates :email, presence: true, uniqueness: true
   validates :username, presence: true, uniqueness: true
   validates :password, length: { minimum: 6 }
+
+  def to_s
+    username
+  end
 end

--- a/app/views/characters/_single_character.html.erb
+++ b/app/views/characters/_single_character.html.erb
@@ -1,7 +1,7 @@
 <div class="single-blog timeline">
   <div class="post-content overflow">
     <h2 class="post-title bold">
-      <%= link_to character.name, character %>
+      <%= link_to character, character %>
     </h2>
 
     <% if character.user %>

--- a/app/views/characters/show.html.erb
+++ b/app/views/characters/show.html.erb
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="row">
       <div class="text-center">
-        <h1><%= @character.name %></h1>
+        <h1><%= @character %></h1>
       </div>
       <% if @character.user %>
       <h3 class="post-author">

--- a/app/views/concepts/_single_concept.html.erb
+++ b/app/views/concepts/_single_concept.html.erb
@@ -1,7 +1,7 @@
 <div class="single-blog timeline">
   <div class="post-content overflow">
     <h2 class="post-title bold">
-      <%= link_to concept.name, concept %>
+      <%= link_to concept, concept %>
     </h2>
     <% if concept.user %>
       <h3 class="post-author">

--- a/app/views/concepts/show.html.erb
+++ b/app/views/concepts/show.html.erb
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="row">
       <div class="text-center">
-        <h1><%= @concept.name %></h1>
+        <h1><%= @concept %></h1>
       </div>
       <div class="tab-container">
         <div class="row">

--- a/app/views/prompts/_left.html.erb
+++ b/app/views/prompts/_left.html.erb
@@ -1,3 +1,3 @@
-<div class="col-sm-6 padding-right arrow-right wow fadeInLeft" data-wow-duration="1000ms" data-wow-delay="300ms">
+<div class="col-sm-6 padding-right wow fadeInLeft" data-wow-duration="1000ms" data-wow-delay="300ms">
   <%= render partial: 'prompts/single_prompt', locals: { prompt: prompt } %>
 </div>

--- a/app/views/prompts/_right.html.erb
+++ b/app/views/prompts/_right.html.erb
@@ -1,3 +1,3 @@
-<div class="col-sm-6 padding-left padding-top arrow-left wow fadeInRight" data-wow-duration="1000ms" data-wow-delay="300ms">
+<div class="col-sm-6 padding-left padding-top wow fadeInRight" data-wow-duration="1000ms" data-wow-delay="300ms">
   <%= render partial: 'prompts/single_prompt', locals: { prompt: prompt } %>
 </div>

--- a/app/views/prompts/_single_prompt.html.erb
+++ b/app/views/prompts/_single_prompt.html.erb
@@ -14,7 +14,7 @@
           <i id="bookmark-<%= prompt.id %>" class="fa fa-bookmark-o"></i>
         <% end %>
       <% end %>
-      <a href="#">Posted by <%= prompt.user.username %></a>
+      <%= link_to "By #{prompt.user}", prompt.user %>
     </h3>
 
     <%= render partial: 'prompts/concepts_and_characters', locals: { prompt: prompt } %>

--- a/app/views/prompts/_success.html.erb
+++ b/app/views/prompts/_success.html.erb
@@ -1,0 +1,4 @@
+<%= link_to prompt, class: 'btn btn-common uppercase', id: "#{prompt.id}-success" do %>
+  <i class="fa fa-check-circle"></i>
+  Your prompt has posted!
+<% end %>

--- a/app/views/prompts/create.js.erb
+++ b/app/views/prompts/create.js.erb
@@ -1,7 +1,17 @@
-if ($('form').last().find('input').val() %2 == 0){
-  var partial = "<%= j render partial: 'prompts/right', locals: { prompt: @prompt } %>"
-}else {
-  var partial = "<%= j render partial: 'prompts/left', locals: { prompt: @prompt } %>"
-}
-$('#list_of_prompts').prepend(partial);
-$('#new_prompt').replaceWith('<%= j render 'new_prompt_btn' %>')
+var $form = $('#new_prompt');
+var $success = $('<%= j render partial: "success", locals: { prompt: @prompt } %>').hide();
+
+$form.slideUp(function(){
+  $(this).replaceWith($success);
+
+  var $successOnDOM = $('#<%= @prompt.id %>-success');
+  var $newPromptBtn = $('<%= j render "new_prompt_btn" %>').hide();
+
+  $successOnDOM.slideDown(function(){
+    window.setTimeout(function(){
+      $successOnDOM.replaceWith($newPromptBtn)
+
+      $('#prompt_new_btn').slideDown();
+    }, 4000);
+  });
+});

--- a/app/views/prompts/index.html.erb
+++ b/app/views/prompts/index.html.erb
@@ -12,7 +12,7 @@
 
         <div class="timeline-blog overflow">
           <div class="timeline-date text-center">
-            <a class="btn btn-common" href="#">See More</a>
+            <%= link_to "See More", prompts_path, class: "btn btn-common uppercase" %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Created a work around for the rendering of prompts to the prompt index. Basically... don't do it. Instead, replace the form with a message saying "Your post was successful!", that turns back to the "New Prompt" link after a few seconds.
